### PR TITLE
fix: correct MessageManager keys for AFK title/subtitle messages

### DIFF
--- a/src/main/java/com/gyvex/ezafk/state/AfkState.java
+++ b/src/main/java/com/gyvex/ezafk/state/AfkState.java
@@ -119,8 +119,8 @@ public class AfkState {
             boolean titleEnabled = plugin.getConfig().getBoolean("afk.title.enabled");
 
             if (titleEnabled) {
-                String title = MessageManager.getMessage("titles.afk.title", "&eAFK");
-                String subtitle = MessageManager.getMessage("titles.afk.subtitle", "&7You are now AFK");
+                String title = MessageManager.getMessage("afk.title.title", "&eAFK");
+                String subtitle = MessageManager.getMessage("afk.title.subtitle", "&7You are now AFK");
 
                 if (title == null) {
                     title = "";
@@ -226,8 +226,8 @@ public class AfkState {
 
         boolean titleEnabled = mode == AfkActivationMode.STANDARD && plugin.getConfig().getBoolean("unafk.title.enabled");
         if (titleEnabled) {
-            String title = MessageManager.getMessage("titles.unafk.title", "&aWelcome back!");
-            String subtitle = MessageManager.getMessage("titles.unafk.subtitle", "&7You are no longer AFK");
+            String title = MessageManager.getMessage("unafk.title.title", "&aWelcome back!");
+            String subtitle = MessageManager.getMessage("unafk.title.subtitle", "&7You are no longer AFK");
 
             if (title == null) {
                 title = "";


### PR DESCRIPTION
Fixes #44

AFK title and subtitle messages were not being displayed from messages.yml because the MessageManager keys in AfkState.java did not match the actual messages.yml structure.

Wrong keys: titles.afk.title, titles.afk.subtitle, titles.unafk.title, titles.unafk.subtitle
Correct keys: afk.title.title, afk.title.subtitle, unafk.title.title, unafk.title.subtitle

Tested on LeafMC 1.21.11 / Java 25.