### PR TITLE
Fix AFK placeholders and bump release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Release tags use the `v` prefix (e.g. `v3.0.0`).
 
 ---
 
+## [3.1.1] - 2026-07-06
+
+[Modrinth](https://modrinth.com/plugin/ezafk/version/3.1.1)
+
+### Fixed
+
+- AFK broadcast and return messages now resolve PlaceholderAPI placeholders
+  with the AFK player's context, so integrations like LuckPerms prefixes work
+  correctly in `messages.yml`.
+
+---
+
 ## [3.1.0] - 2026-05-23
 
 [Modrinth](https://modrinth.com/plugin/ezafk/version/3.1.0)

--- a/bbcode-topic.md
+++ b/bbcode-topic.md
@@ -9,7 +9,7 @@
 
 [B]EzAfk[/B] is a modern, lightweight AFK management plugin built for Paper and Spigot servers running Minecraft **1.21+** and Java **21+**. It automates AFK detection, rewards or charges players based on AFK state, provides staff overview tools, and integrates with the systems you already use, all without sacrificing performance.
 
-[IMG]https://img.shields.io/badge/version-3.1.0-blue[/IMG]
+[IMG]https://img.shields.io/badge/version-3.1.1-blue[/IMG]
 [IMG]https://img.shields.io/badge/Minecraft-1.21%2B-green[/IMG]
 [IMG]https://img.shields.io/badge/Java-21%2B-orange[/IMG]
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.gyvex</groupId>
     <artifactId>ezafk</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/gyvex/ezafk/manager/MessageManager.java
+++ b/src/main/java/com/gyvex/ezafk/manager/MessageManager.java
@@ -3,8 +3,10 @@ package com.gyvex.ezafk.manager;
 import com.gyvex.ezafk.EzAfk;
 import com.gyvex.ezafk.bootstrap.Registry;
 import com.gyvex.ezafk.state.AfkState;
+import com.gyvex.ezafk.util.PlaceholderUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 import java.util.Map;
 
@@ -18,11 +20,16 @@ public final class MessageManager {
     }
 
     public static void sendMessage(CommandSender sender, String path, String fallback, Map<String, String> placeholders) {
+        sendMessage(sender, path, fallback, placeholders, sender instanceof Player ? (Player) sender : null);
+    }
+
+    public static void sendMessage(CommandSender sender, String path, String fallback,
+                                   Map<String, String> placeholders, Player playerContext) {
         if (sender == null) {
             return;
         }
 
-        String message = getMessage(path, fallback, placeholders);
+        String message = getMessage(path, fallback, placeholders, playerContext);
 
         if (message != null && !message.isEmpty()) {
             sender.sendMessage(message);
@@ -34,6 +41,10 @@ public final class MessageManager {
     }
 
     public static String getMessage(String path, String fallback, Map<String, String> placeholders) {
+        return getMessage(path, fallback, placeholders, null);
+    }
+
+    public static String getMessage(String path, String fallback, Map<String, String> placeholders, Player playerContext) {
         String message = null;
         if (Registry.get().getConfigManager() != null && Registry.get().getConfigManager().getMessages() != null) {
             message = Registry.get().getConfigManager().getMessages().getString(path);
@@ -55,6 +66,10 @@ public final class MessageManager {
         }
 
         message = applyGlobalPlaceholders(message);
+
+        if (playerContext != null) {
+            message = PlaceholderUtil.resolvePlaceholderApiPlaceholders(playerContext, message, Registry.get().getLogger());
+        }
 
         return ChatColor.translateAlternateColorCodes('&', message);
     }

--- a/src/main/java/com/gyvex/ezafk/state/AfkState.java
+++ b/src/main/java/com/gyvex/ezafk/state/AfkState.java
@@ -119,8 +119,8 @@ public class AfkState {
             boolean titleEnabled = plugin.getConfig().getBoolean("afk.title.enabled");
 
             if (titleEnabled) {
-                String title = MessageManager.getMessage("afk.title.title", "&eAFK");
-                String subtitle = MessageManager.getMessage("afk.title.subtitle", "&7You are now AFK");
+                String title = MessageManager.getMessage("afk.title.title", "&eAFK", null, player);
+                String subtitle = MessageManager.getMessage("afk.title.subtitle", "&7You are now AFK", null, player);
 
                 if (title == null) {
                     title = "";
@@ -206,7 +206,7 @@ public class AfkState {
         }
 
         if (mode == AfkActivationMode.STANDARD) {
-            MessageManager.sendMessage(player, "afk.no-longer", "&aYou are no longer AFK!");
+            MessageManager.sendMessage(player, "afk.no-longer", "&aYou are no longer AFK!", null, player);
         }
 
         if (mode == AfkActivationMode.STANDARD && plugin.getConfig().getBoolean("unafk.broadcast.enabled")) {
@@ -226,8 +226,8 @@ public class AfkState {
 
         boolean titleEnabled = mode == AfkActivationMode.STANDARD && plugin.getConfig().getBoolean("unafk.title.enabled");
         if (titleEnabled) {
-            String title = MessageManager.getMessage("unafk.title.title", "&aWelcome back!");
-            String subtitle = MessageManager.getMessage("unafk.title.subtitle", "&7You are no longer AFK");
+            String title = MessageManager.getMessage("unafk.title.title", "&aWelcome back!", null, player);
+            String subtitle = MessageManager.getMessage("unafk.title.subtitle", "&7You are no longer AFK", null, player);
 
             if (title == null) {
                 title = "";
@@ -356,7 +356,7 @@ public class AfkState {
             placeholders.put("player", replacement);
         }
 
-        return MessageManager.getMessage(path, fallback, placeholders);
+        return MessageManager.getMessage(path, fallback, placeholders, player);
     }
 
     private static void applyAfkDisplayName(EzAfk plugin, Player player) {

--- a/src/main/java/com/gyvex/ezafk/util/PlaceholderUtil.java
+++ b/src/main/java/com/gyvex/ezafk/util/PlaceholderUtil.java
@@ -101,6 +101,29 @@ public class PlaceholderUtil {
     }
 
     /**
+     * Resolves PlaceholderAPI placeholders using the provided player context without applying
+     * EzAfk's local %player% or %executor% substitutions.
+     */
+    public static String resolvePlaceholderApiPlaceholders(Player player, String text, Logger logger) {
+        if (text == null) {
+            return null;
+        }
+
+        if (!isPlaceholderAPIAvailable(logger)) {
+            return text;
+        }
+
+        try {
+            return me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(player, text);
+        } catch (Exception e) {
+            if (logger != null) {
+                logger.warning("Failed to resolve placeholders via PlaceholderAPI: " + e.getMessage());
+            }
+            return text;
+        }
+    }
+
+    /**
      * Resolves placeholders without player context (server-wide/offline placeholders).
      */
     public static String resolvePlaceholders(String text, Logger logger) {

--- a/topics/modrinth-topic.md
+++ b/topics/modrinth-topic.md
@@ -7,7 +7,7 @@ It automates AFK detection, rewards or charges players based on idle state, give
 a real-time overview panel, and integrates with the tools you already run, all without
 sacrificing performance.
 
-> **v3.1.0** · Minecraft 1.21+ · Java 21+ · Paper / Spigot / Bukkit / Purpur
+> **v3.1.1** · Minecraft 1.21+ · Java 21+ · Paper / Spigot / Bukkit / Purpur
 
 ---
 


### PR DESCRIPTION
### Fixed

- AFK broadcast and return messages now resolve PlaceholderAPI placeholders
  with the AFK player's context, so integrations like LuckPerms prefixes work
  correctly in `messages.yml`.